### PR TITLE
Add `replace` macro to replace dependencies

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,7 +20,6 @@ defmodule Pact.Mixfile do
     [
       {:earmark, "~> 0.1", only: :dev},
       {:ex_doc, "~> 0.6", only: :dev},
-      {:meck, "~> 0.8.2"}
     ]
   end
 


### PR DESCRIPTION
Add `replace` macro which allows you to define a fake module inline that
generates a unique, fake module with the given block.
- Remove meck dependency
- Remove override with anonymous function syntax
- Remove useless `deep_get`
