### PR TITLE
replacing dependencies on process for async testing

### DIFF
--- a/lib/pact.ex
+++ b/lib/pact.ex
@@ -79,6 +79,7 @@ defmodule Pact do
         end
       end
 
+
       defmacro replace(name, module, where \\ :registry, do: block) do
         quote do
           existing_module = unquote(__MODULE__).get(unquote(name))
@@ -88,22 +89,13 @@ defmodule Pact do
         end
       end
 
-      def register(name, module, :process) do
-        Process.put(name, module)
-      end
-
-      def register(name, module, where \\ :registry ) do
-        GenServer.cast(__MODULE__, {:register, name, module})
-      end
+      def register(name, module), do: register(name, module, :registry)
+      def register(name, module, :process), do: Process.put(name, module)
+      def register(name, module, where ), do: GenServer.cast(__MODULE__, {:register, name, module})
 
 
-      def get(name) do
-        Process.get(name, get(name, :registry))
-      end
-
-      def get(name, :registry) do
-        GenServer.call(__MODULE__, {:get, name})
-      end
+      def get(name), do: Process.get(name, get(name, :registry))
+      def get(name, :registry), do: GenServer.call(__MODULE__, {:get, name})
 
       # Genserver implementation
 

--- a/lib/pact.ex
+++ b/lib/pact.ex
@@ -51,7 +51,7 @@ defmodule Pact do
 
   ## Functions / Macros
 
-  * `generate(name, block)` - Generates an anonymous module that's body is 
+  * `generate(name, block)` - Generates an anonymous module that's body is
     block`.
   * `replace(name, module, block)` - Replaces `name` with `module` in the given
     `block` only.
@@ -79,20 +79,29 @@ defmodule Pact do
         end
       end
 
-      defmacro replace(name, module, do: block) do
+      defmacro replace(name, module, where \\ :registry, do: block) do
         quote do
           existing_module = unquote(__MODULE__).get(unquote(name))
-          unquote(__MODULE__).register(unquote(name), unquote(module))
+          unquote(__MODULE__).register(unquote(name), unquote(module), unquote(where))
           unquote(block)
-          unquote(__MODULE__).register(unquote(name), existing_module)
+          unquote(__MODULE__).register(unquote(name), existing_module, unquote(where))
         end
       end
 
-      def register(name, module) do
+      def register(name, module, :process) do
+        Process.put(name, module)
+      end
+
+      def register(name, module, where \\ :registry ) do
         GenServer.cast(__MODULE__, {:register, name, module})
       end
 
+
       def get(name) do
+        Process.get(name, get(name, :registry))
+      end
+
+      def get(name, :registry) do
         GenServer.call(__MODULE__, {:get, name})
       end
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,10 +5,10 @@ defmodule Pact.Mixfile do
     [app: :pact,
      version: "0.2.0",
      elixir: "~> 1.0",
-     deps: deps,
-     description: description,
+     deps: deps(),
+     description: description(),
      source_url: "https://github.com/BlakeWilliams/pact",
-     package: package
+     package: package()
    ]
   end
 

--- a/test/pact_test.exs
+++ b/test/pact_test.exs
@@ -65,7 +65,7 @@ defmodule PactTest do
       def get(url), do: "#{url}/alternate"
     end
 
-    1..10000
+    1..100000
       |> Enum.map(fn indx ->
         [
           Task.async(fn  -> replace(fakeHTTP, indx, indx) end),


### PR DESCRIPTION
When running async tests and replacing dependencies there are situations when one test will replace a dependency used in another. 

This PR adds an optional atom :process/:registry on the replace method. If the process method is used then it will only replace the dependency for that process otherwise it will replace it for the whole registry (i.e. the genserver). 

When retrieving the dependency it will first check the process and if its not there go to the registry.  

```
FakeApp.Pact.replace "http", module, :process do
   assert FakeApp.Pact.get("http").get(input) == assertion
end
```

Not sure this is the best approach just first thing I could think of. 