### PR TITLE
Auto resolve function dependencies

### DIFF
--- a/lib/auto_resolve.ex
+++ b/lib/auto_resolve.ex
@@ -1,0 +1,32 @@
+defmodule Pact.AutoResolve do
+
+  defmacro __using__(_) do
+    quote do
+      require Annotatable
+      use Annotatable, [:resolve]
+      @before_compile Pact.AutoResolve
+    end
+  end
+
+  defmacro __before_compile__(env) do
+    annotations = Module.get_attribute(env.module, :annotations)
+    annotations |> Enum.map(fn {name, [%{method_info: method_info, value: value}]} ->
+      {args, _guards, _} = method_info
+      [dependencies | no_dep_args] = Enum.reverse args
+      no_dep_args =  Enum.reverse no_dep_args
+      dependency_keys = dependencies |> Enum.map(fn {name, _} -> name end)
+
+      quote do
+        def unquote(:"#{name}")(unquote_splicing(no_dep_args)) do
+          deps = unquote(dependency_keys) |> Enum.map(fn key ->
+            {key, unquote(value).get(key)}
+          end)
+          deps = unquote(no_dep_args) ++ [deps]
+          apply(__MODULE__, unquote(name), deps)
+        end
+      end
+
+    end)
+  end
+
+end

--- a/lib/pact.ex
+++ b/lib/pact.ex
@@ -89,11 +89,15 @@ defmodule Pact do
         end
       end
 
+      def register(name, module) do
+         register(name, module, :registry)
+      end
+
       def register(name, module, :process) do
         Process.put(name, module)
       end
 
-      def register(name, module, where \\ :registry ) do
+      def register(name, module, :registry ) do
         GenServer.cast(__MODULE__, {:register, name, module})
       end
 
@@ -130,7 +134,7 @@ defmodule Pact do
     end
   end
 
-  defmacro __before_compile__(env) do
+  defmacro __before_compile__(_env) do
     quote do
       def start_link do
         GenServer.start_link(__MODULE__, %{modules: @modules}, name: __MODULE__)

--- a/lib/pact/auto_resolve.ex
+++ b/lib/pact/auto_resolve.ex
@@ -11,7 +11,7 @@ defmodule Pact.AutoResolve do
   defmacro __before_compile__(env) do
     annotations = Module.get_attribute(env.module, :annotations)
     annotations |> Enum.map(fn {name, [%{method_info: method_info, value: value}]} ->
-      {args, _guards, _} = method_info
+      {args, _, _} = method_info
       [dependencies | no_dep_args] = Enum.reverse args
       no_dep_args =  Enum.reverse no_dep_args
       dependency_keys = dependencies |> Enum.map(fn {name, _} -> name end)

--- a/mix.exs
+++ b/mix.exs
@@ -20,6 +20,7 @@ defmodule Pact.Mixfile do
     [
       {:earmark, "~> 0.1", only: :dev},
       {:ex_doc, "~> 0.6", only: :dev},
+      {:annotatable, "~> 0.1.2"},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,3 @@
-%{"earmark": {:hex, :earmark, "0.1.12"},
-  "ex_doc": {:hex, :ex_doc, "0.7.0"}}
+%{"annotatable": {:hex, :annotatable, "0.1.2", "29103613c986d7f56a80635a4548fa54a9c1011e4c419f4dbc8607f1c4bd3e9f", [:mix], []},
+  "earmark": {:hex, :earmark, "0.1.12", "ae057eb004b23ecd32125608efbb33be8b924db54e56ae69a8cb113362b2463c", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.7.0", "127d10d02dd7810cd52f1cda68195d137ad2b426100f98db45d272fced8a32c6", [:mix], []}}

--- a/test/auto_resolve_test.exs
+++ b/test/auto_resolve_test.exs
@@ -1,0 +1,33 @@
+defmodule Foo do
+  def bar(argument), do: "foo:#{argument}"
+end
+
+defmodule ResolvedFakeApp.Pact do
+  use Pact
+
+  register :foo, Foo
+end
+
+defmodule ResolvedFakeApp.AutoResolve do
+  use Pact.AutoResolve
+
+  @resolve ResolvedFakeApp.Pact
+  def resolve(arg, [foo: foo]) do
+     foo.bar(arg)
+  end
+end
+
+defmodule AutoResolveTest do
+  use ExUnit.Case, async: true
+
+  setup_all do
+    ResolvedFakeApp.Pact.start_link
+    :ok
+  end
+
+  test "automatically resolve pact dependencies" do
+    require ResolvedFakeApp.Pact
+    assert ResolvedFakeApp.AutoResolve.resolve("arg") == "foo:arg"
+  end
+
+end


### PR DESCRIPTION
_NOTE: This is WIP, but I will not continue with this if you don't like the concept it might be a bit magic._ 

I wanted a way of automatically resolving the dependencies registered in PACT, so I added a macro to do this. It means I can do:

```
defmodule MyApp.MyModule do
   use Pact.AutoResolve

  @resolve MyApp.Pact
  def resolved_method(arg, [foo: foo]) do
     foo.bar(arg)
  end
end
```

This will allow us to call `resolved_method/1` and `foo` will be resolved from PACT based on the key `:foo` i.e.

```
defmodule MyApp.Pact do
  use Pact

  register :foo, Foo
end
```

Can still do all the replacing of dependencies, but really as `resolved_method/2` takes its dependencies in that can just be called with stub dependencies directly.  